### PR TITLE
Increase the timeout 

### DIFF
--- a/cmd/csi-snapshotter/main.go
+++ b/cmd/csi-snapshotter/main.go
@@ -51,7 +51,7 @@ const (
 	threads = 10
 
 	// Default timeout of short CSI calls like GetPluginInfo
-	csiTimeout = time.Second
+	csiTimeout = time.Minute
 )
 
 // Command line flags
@@ -191,7 +191,7 @@ func main() {
 		*createSnapshotContentRetryCount,
 		*createSnapshotContentInterval,
 		snapShotter,
-		*connectionTimeout,
+		csiTimeout,
 		*resyncPeriod,
 		*snapshotNamePrefix,
 		*snapshotNameUUIDLength,


### PR DESCRIPTION
Right now, snapshotter gives timeouts for every CSI operation. We need to increase the duration for timeouts.